### PR TITLE
fixed github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ repository locally, then create a remote repo and connect them.
 We've got our local work ready to go, so now we need to set up a new remote
 repository to store this in.
 
-* Open a new browser tab and go to <a href="github.com" target="_blank">github.com</a>
+* Open a new browser tab and go to <a href="https://www.github.com" target="_blank">github.com</a>
   and make sure you are signed in.
 * In the upper right-hand corner of the page, click the **`+`** button and
   choose **_New repository_**


### PR DESCRIPTION
the GitHub link was missing "https://www." turning it into a relative link to
https://learn.co/tracks/full-stack-web-development-v5/html-and-css-continued/html-fundamentals/github.com
which forwards to this lesson https://learn.co/tracks/full-stack-web-development-v5/html-and-css-continued/html-fundamentals/setting-up-a-new-site?batch_id=306&track_id=31303